### PR TITLE
Add /setup command to automate dependency installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,100 +2,14 @@
 
 Team onboarding plugin with clarity workflow commands, worktree skill, and commit guards.
 
-## Dependencies
-
-Install these before using the plugin:
-
-**jq** (JSON processor - required for hooks):
-```bash
-# Ubuntu/Debian
-sudo apt install jq
-
-# Mac
-brew install jq
-```
-
-**gh** (GitHub CLI):
-```bash
-curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
-sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
-echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-sudo apt update
-sudo apt install gh
-gh auth login
-```
-
-**uv** (Python package manager):
-```bash
-curl -LsSf https://astral.sh/uv/install.sh | sh
-```
-
-**git-worktree-runner** (worktree management):
-```bash
-git clone https://github.com/coderabbitai/git-worktree-runner.git
-cd git-worktree-runner
-./install.sh
-```
-
-**Homebrew** (package manager for WSL):
-```bash
-# Install build-essential first (required for WSL)
-sudo apt-get update
-sudo apt-get install build-essential
-
-# Install Homebrew
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-
-# Add to PATH
-test -d ~/.linuxbrew && eval $(~/.linuxbrew/bin/brew shellenv)
-test -d /home/linuxbrew/.linuxbrew && eval $(/home/linuxbrew/.linuxbrew/bin/brew shellenv)
-echo "eval \$($(brew --prefix)/bin/brew shellenv)" >> ~/.bashrc
-source ~/.bashrc
-```
-
-**Supabase CLI** (database operations):
-```bash
-npm install -g supabase
-supabase login
-```
-
-**hand-picked-tools MCP** (AI tools):
-```bash
-claude mcp add hand-picked-tools --transport http --scope user https://metamcp.iitr-cloud.de/metamcp/hand-picked-tools/mcp
-```
-
-**Google Chrome** (for Chrome DevTools MCP):
-```bash
-wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-sudo dpkg -i google-chrome-stable_current_amd64.deb
-sudo apt --fix-broken install
-```
-
-**mcp2rest** (MCP gateway - optional):
-```bash
-npm install -g mcp2rest
-
-# Install as service (use env to preserve PATH for nvm users)
-sudo env "PATH=$PATH" npx mcp2rest service install
-
-# Or run in foreground
-npx mcp2rest start
-
-# Add Chrome DevTools server
-npx mcp2rest add chrome chrome-devtools-mcp@latest
-
-# Verify
-curl http://localhost:28888/health
-```
-
 ## Install
-
-### Public Repository (default)
 
 ```
 /plugin marketplace add MariusWilsch/claude-code-team-marketplace
 /plugin install claude-code-team-plugin@wilsch-ai-plugins
 ```
+
+Restart Claude Code, then run `/setup` in a new session — it detects your OS and installs all required dependencies (jq, gh, uv) automatically.
 
 ### Update
 
@@ -168,6 +82,7 @@ source ~/.zshrc  # or source ~/.bashrc
 
 | Command | Purpose |
 |---------|---------|
+| `/setup` | Install dependencies and configure MCP (run once after install) |
 | `/onboarding` | Start session, link issue, bootstrap context |
 | `/requirements-clarity` | Disambiguate WHAT to build |
 | `/implementation-clarity` | Plan HOW to build |

--- a/plugins/claude-code-team-plugin/commands/setup.md
+++ b/plugins/claude-code-team-plugin/commands/setup.md
@@ -1,0 +1,66 @@
+---
+description: "Install dependencies and configure MCP for claude-code-team-plugin"
+---
+
+### 1. Task context
+Run first-time setup for the claude-code-team-plugin. Install core CLI tools, verify GitHub auth, and add the hand-picked-tools MCP server. Produce a clear final checklist showing what's ready and what (if anything) still needs manual action.
+
+### 2. Tone context
+Clear progress per step. Short and practical — not verbose. End with a scannable summary.
+
+### 3. Detailed task description
+
+**Step 1: Run dependency installer**
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/setup.sh"
+```
+
+If the script exits non-zero, show the output and stop — do not continue to the next steps.
+
+**Step 2: Check GitHub CLI authentication**
+
+```bash
+gh auth status 2>&1
+```
+
+- Authenticated → note ✅
+- Not authenticated → note that user must run `gh auth login` manually (requires browser/interactive terminal, cannot be automated)
+
+**Step 3: Check and add hand-picked-tools MCP**
+
+Check if already configured:
+```bash
+grep -r "hand-picked-tools" ~/.claude/settings.json ~/.claude/settings.local.json 2>/dev/null | head -1
+```
+
+If no output (missing), add it:
+```bash
+claude mcp add hand-picked-tools --transport http --scope user https://metamcp.iitr-cloud.de/metamcp/hand-picked-tools/mcp
+```
+
+**Step 4: Show setup summary**
+
+Print a final checklist:
+
+```
+✅ Setup Complete
+
+Core tools:       jq ✓   gh ✓   uv ✓
+GitHub auth:      [✅ authenticated  /  ⚠ run: gh auth login]
+MCP tools:        hand-picked-tools ✓
+
+[If uv was just installed, also show:]
+⚠  Shell restart required for uv PATH:
+   source ~/.zshrc    # zsh
+   source ~/.bashrc   # bash
+
+[If gh not authenticated:]
+Manual step:
+  gh auth login
+```
+
+Once all items are ✅, tell the user they're ready to run `/onboarding`.
+
+### 7. Immediate task description or request
+Run first-time setup: install core deps, check GitHub auth, configure hand-picked-tools MCP.

--- a/plugins/claude-code-team-plugin/scripts/setup.sh
+++ b/plugins/claude-code-team-plugin/scripts/setup.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+# setup.sh - Install core dependencies for claude-code-team-plugin
+#
+# Design Context:
+#   Checks for jq, gh, uv — the three tools required by hooks and lib scripts.
+#   OS-aware: macOS uses brew, Linux prefers brew if present, falls back to apt + curl.
+#   Pass --check to report status without installing (dry-run).
+#   uv modifies shell rc files but not the current shell — user must restart shell after install.
+
+set -uo pipefail
+
+CHECK_ONLY="${1:-}"
+FAILED=()
+UV_INSTALLED=false
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+ok()   { echo -e "  ${GREEN}✓${NC} $1"; }
+miss() { echo -e "  ${RED}✗${NC} $1 (not found)"; }
+info() { echo -e "  ${BLUE}→${NC} $1"; }
+fail() { echo -e "  ${RED}✗${NC} $1 (install failed)"; FAILED+=("$1"); }
+
+detect_os() {
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        echo "mac"
+    elif grep -qi microsoft /proc/version 2>/dev/null; then
+        echo "wsl"
+    elif [[ -f /etc/os-release ]]; then
+        echo "linux"
+    else
+        echo "unknown"
+    fi
+}
+
+OS=$(detect_os)
+
+install_jq() {
+    if [[ "$OS" == "mac" ]] || command -v brew &>/dev/null; then
+        brew install jq
+    else
+        sudo apt-get install -y jq
+    fi
+}
+
+install_gh() {
+    if [[ "$OS" == "mac" ]] || command -v brew &>/dev/null; then
+        brew install gh
+    else
+        # Official GitHub CLI apt source
+        curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+            | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg 2>/dev/null
+        sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
+        echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+            | sudo tee /etc/apt/sources.list.d/github-cli.list >/dev/null
+        sudo apt-get update -qq
+        sudo apt-get install -y gh
+    fi
+}
+
+install_uv() {
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+    UV_INSTALLED=true
+}
+
+check_dep() {
+    local name="$1"
+    local binary="$2"
+    local install_fn="$3"
+
+    if command -v "$binary" &>/dev/null; then
+        ok "$name"
+        return
+    fi
+
+    if [[ -n "$CHECK_ONLY" ]]; then
+        miss "$name"
+        return
+    fi
+
+    info "Installing $name..."
+    if "$install_fn"; then
+        # uv modifies PATH via rc file — binary won't be on PATH in current shell
+        if [[ "$name" == "uv" ]] || command -v "$binary" &>/dev/null; then
+            ok "$name"
+        else
+            fail "$name"
+        fi
+    else
+        fail "$name"
+    fi
+}
+
+echo ""
+echo "🔧 Claude Code Team Plugin — Dependency Setup"
+echo "=============================================="
+echo "Platform: $OS"
+echo ""
+
+check_dep "jq" "jq" install_jq
+check_dep "gh" "gh" install_gh
+check_dep "uv" "uv" install_uv
+
+echo ""
+
+if [[ ${#FAILED[@]} -gt 0 ]]; then
+    echo -e "${RED}❌ Failed: ${FAILED[*]}${NC}"
+    echo "   Try running with sudo, or install manually."
+    exit 1
+elif [[ -n "$CHECK_ONLY" ]]; then
+    echo "Run without --check to install missing dependencies."
+else
+    echo -e "${GREEN}✅ Core dependencies ready${NC}"
+fi
+
+if [[ "$UV_INSTALLED" == true ]]; then
+    echo ""
+    echo -e "${YELLOW}⚠  uv was just installed — restart your shell before continuing:${NC}"
+    echo "   source ~/.zshrc    # zsh"
+    echo "   source ~/.bashrc   # bash"
+fi


### PR DESCRIPTION
Created setup slash command for initial installaiton of dependencies. No hook for post istall of plusings yet.


- scripts/setup.sh: OS-aware installer for jq, gh, uv (macOS brew / Linux apt+curl)
- commands/setup.md: Claude command that runs setup script, checks gh auth, adds hand-picked-tools MCP
- README: replace 80-line manual dependency wall with 3-line install + "run /setup"

