### PR TITLE
Add user consent gate for session log collection

### DIFF
--- a/plugins/claude-code-team-plugin/commands/setup.md
+++ b/plugins/claude-code-team-plugin/commands/setup.md
@@ -39,7 +39,35 @@ If no output (missing), add it:
 claude mcp add hand-picked-tools --transport http --scope user https://metamcp.iitr-cloud.de/metamcp/hand-picked-tools/mcp
 ```
 
-**Step 4: Show setup summary**
+**Step 4: Session log consent**
+
+Use AskUserQuestion to ask the user whether they consent to session log collection:
+
+```
+Question: "Can Traceline collect your Claude Code session transcripts?"
+
+Context to show the user:
+  Session transcripts are your full conversation logs with Claude (the .jsonl files
+  Claude Code saves locally). Uploading them lets us power features like
+  /flag-for-improvement and improve the plugin based on real usage.
+  You can change this any time by running /setup again.
+
+Options:
+  - "Yes — upload sessions automatically"
+  - "No — keep sessions local only"
+```
+
+Based on the answer, write the consent file:
+
+```bash
+# If yes:
+echo "yes" > ~/.claude/.traceline-consent
+
+# If no:
+echo "no" > ~/.claude/.traceline-consent
+```
+
+**Step 5: Show setup summary**
 
 Print a final checklist:
 
@@ -49,6 +77,7 @@ Print a final checklist:
 Core tools:       jq ✓   gh ✓   uv ✓
 GitHub auth:      [✅ authenticated  /  ⚠ run: gh auth login]
 MCP tools:        hand-picked-tools ✓
+Session logs:     [✅ uploading  /  ⊘ local only]
 
 [If uv was just installed, also show:]
 ⚠  Shell restart required for uv PATH:

--- a/plugins/claude-code-team-plugin/scripts/session-upload.sh
+++ b/plugins/claude-code-team-plugin/scripts/session-upload.sh
@@ -8,6 +8,11 @@
 
 set -o pipefail
 
+# Check user consent — skip silently if not given
+if [[ "$(cat ~/.claude/.traceline-consent 2>/dev/null)" != "yes" ]]; then
+    exit 0
+fi
+
 # Find destination repo - check dev path first, then derive from CLAUDE_PLUGIN_ROOT
 DEV_PATH="$HOME/Documents/projects/claude-code-team-plugin"
 SEARCHED_PATHS="$DEV_PATH"


### PR DESCRIPTION
## Summary

- `/setup` now asks users to explicitly opt in or out of session log uploads via `AskUserQuestion`
- Consent stored in `~/.claude/.traceline-consent` (`yes` / `no`)
- `session-upload.sh` checks consent at startup — skips silently if missing or `no`

## What's not included

Upload destination is not yet resolved — tracked in #4. Session upload currently still targets the original dev path; once #4 is decided, the destination logic in `session-upload.sh` can be updated separately.

## Test plan

- [ ] Run `/setup` — consent prompt appears with clear explanation
- [ ] Select "No" — `~/.claude/.traceline-consent` contains `no`, session-upload skips on next session end
- [ ] Select "Yes" — `~/.claude/.traceline-consent` contains `yes`, session-upload proceeds
- [ ] Re-run `/setup` — consent can be changed, file is overwritten

Closes #4 (partially — consent gate only, upload destination deferred)

🤖 Generated with [Claude Code](https://claude.com/claude-code)